### PR TITLE
Support Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^8.1",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^10.0 || ^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Hi there, this expands the range of `illuminate/contracts` to allow the install of this package in apps with Laravel 11.